### PR TITLE
bacon: Introduce panel-based ODM manifests

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -55,6 +55,12 @@ TARGET_FS_CONFIG_GEN := $(DEVICE_PATH)/config.fs
 # Init
 SOONG_CONFIG_OPPO_MSM8974_INIT_DEVICE_LIB := //$(DEVICE_PATH):libinit_bacon
 
+# ODM Manifests
+ODM_MANIFEST_SKUS := jdi sharp truly
+ODM_MANIFEST_JDI_FILES := $(DEVICE_PATH)/odm_manifest_jdi.xml
+ODM_MANIFEST_SHARP_FILES := $(DEVICE_PATH)/odm_manifest_sharp.xml
+ODM_MANIFEST_TRULY_FILES := $(DEVICE_PATH)/odm_manifest_truly.xml
+
 # Properties
 TARGET_SYSTEM_PROP += $(DEVICE_PATH)/system.prop
 

--- a/init/init_bacon.cpp
+++ b/init/init_bacon.cpp
@@ -61,7 +61,21 @@ static void import_kernel_nv(const std::string& key, const std::string& value)
     }
 }
 
+static void vendor_set_sku(const std::string& key, const std::string& value)
+{
+    if (key.empty()) return;
+
+    if (key == "mdss_mdp.panel" && value == "1:dsi:0:qcom,mdss_dsi_jdi_1080p_cmd") {
+        property_override("ro.boot.hardware.sku", "jdi");
+    } else if (key == "mdss_mdp.panel" && value == "1:dsi:0:qcom,mdss_dsi_sharp_1080p_cmd") {
+        property_override("ro.boot.hardware.sku", "sharp");
+    } else if (key == "mdss_mdp.panel" && value == "1:dsi:0:qcom,mdss_dsi_truly_1080p_cmd") {
+        property_override("ro.boot.hardware.sku", "truly");
+    }
+}
+
 void vendor_load_device_properties()
 {
     import_kernel_cmdline(import_kernel_nv);
+    import_kernel_cmdline(vendor_set_sku);
 }

--- a/odm_manifest_jdi.xml
+++ b/odm_manifest_jdi.xml
@@ -1,0 +1,27 @@
+<manifest version="1.0" type="device">
+   <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAdaptiveBacklight</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IAutoContrast</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IColorEnhancement</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IDisplayColorCalibration</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>ISunlightEnhancement</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/odm_manifest_sharp.xml
+++ b/odm_manifest_sharp.xml
@@ -1,0 +1,23 @@
+<manifest version="1.0" type="device">
+   <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAdaptiveBacklight</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IAutoContrast</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IDisplayColorCalibration</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>ISunlightEnhancement</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/odm_manifest_truly.xml
+++ b/odm_manifest_truly.xml
@@ -1,0 +1,27 @@
+<manifest version="1.0" type="device">
+   <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IAdaptiveBacklight</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IAutoContrast</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IColorEnhancement</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IDisplayColorCalibration</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>ISunlightEnhancement</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/rootdir/etc/init.bacon.rc
+++ b/rootdir/etc/init.bacon.rc
@@ -16,6 +16,10 @@
 
 import /vendor/etc/init/hw/init.qcom-common.rc
 
+on init
+    # Property used by vintf for sku specific manifests
+    setprop ro.boot.product.hardware.sku ${ro.boot.hardware.sku}
+
 on fs
     mount_all /vendor/etc/fstab.bacon --early
 


### PR DESCRIPTION
* bacon has 3 potential panels, `jdi`, `sharp`, and `truly`.
  The `sharp` panel doesn't support IColorEnhancement.
  Because some panels (jdi, truly) do support it, LD
  fires up the interface, meaning we need the manifest
  entry according to Android 11's VINT manifest hosting
  enforcement. So, in bringup I did this, but as you can
  probably guess, this just shifted the problem to `sharp`
  panels.

* To remediate this, we can jsut declare 3 ODM manifests
  based on the panel (which is determined by init
  reading out the `/proc/cmdline` entry and parsing it
  for the devices installed panel, then setting `ro.hardware.sku`
  to the panel manufacturer, and having 3 separate ODM manifests
  that load based on that property.

* Logic for cmdline parsing stolen from:
  `system/core/init/selinux.cpp`

* This sucks, but hey, it's better than `panel.sh` lol.

* Special thanks to javelinanddart, razorloves, Luk1337,
  and haggertk (even if just for joke above).

Reference: https://gitlab.com/LineageOS/issues/android/-/issues/3275
Change-Id: I1e6fad58733d2bdefd123be2a65b41932ab24623